### PR TITLE
fix crash on iOS 10 about privacy

### DIFF
--- a/GLCameraRipple/GLCameraRipple-Info.plist
+++ b/GLCameraRipple/GLCameraRipple-Info.plist
@@ -51,5 +51,7 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Use your Camera to capture video.</string>	
 </dict>
 </plist>


### PR DESCRIPTION
fix crash:
 [access] This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSCameraUsageDescription key with a string value explaining to the user how the app uses this data.